### PR TITLE
feat: progress subscription stream을 callback 형태로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ All video files are encoded in an MP4 container with AAC audio that allows 100% 
 
 Works on ANDROID, IOS and desktop (just MacOS for now).
 
-
+# 수정사항
+- 3.1.2 버전 수정
+- 기존에 listen하는 방식이 아닌 callback 형태로 수정(subscription.dart)
 
 # Table of Contents
   - [Installing](#lets-get-started)

--- a/lib/src/progress_callback/subscription.dart
+++ b/lib/src/progress_callback/subscription.dart
@@ -1,30 +1,20 @@
-import 'dart:async';
-
-import 'dart:ui';
+typedef UpdateProgressCallback = Function(double progress);
 
 class ObservableBuilder<T> {
-  StreamController<T> _observable = StreamController();
   bool notSubscribed = true;
+  Subscription? _subscription;
 
-  void next(T value) {
-    _observable.add(value);
+  void next(double value) {
+    _subscription?.updateProgressCallback?.call(value);
   }
 
-  Subscription subscribe(void Function(T event) onData,
-      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+  Subscription subscribe(UpdateProgressCallback? updateProgressCallback) {
     notSubscribed = false;
-    _observable.stream.listen(onData,
-        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
-    return Subscription(() {
-      _observable.close();
-
-      // Create a new instance to avoid errors
-      _observable = StreamController();
-    });
+    return _subscription = Subscription(updateProgressCallback: updateProgressCallback);
   }
 }
 
 class Subscription {
-  final VoidCallback unsubscribe;
-  const Subscription(this.unsubscribe);
+  final UpdateProgressCallback? updateProgressCallback;
+  const Subscription({this.updateProgressCallback});
 }


### PR DESCRIPTION
## 작업내용

### 문제
- background에서 foreground 전환후 compress 실행시 `Bad state: Stream has already been listened to` 에러 확인

### 해결
- progress subscription 형태에서 callback 형태로 수정
- README 수정

[해당티켓](https://bemily.atlassian.net/browse/DFLT-473?atlOrigin=eyJpIjoiNDYwNTY3MzJiOTA4NDA0NDk0ZGFlMjFhYmEyNTQ0N2EiLCJwIjoiaiJ9)